### PR TITLE
Fix routes for taxi and health endpoints

### DIFF
--- a/backend/models/Taxi.js
+++ b/backend/models/Taxi.js
@@ -82,7 +82,6 @@ const taxiSchema = new mongoose.Schema({
 // 지리공간 인덱스
 taxiSchema.index({ currentLocation: '2dsphere' });
 taxiSchema.index({ status: 1 });
-taxiSchema.index({ taxiNumber: 1 });
 
 // 가상 필드
 taxiSchema.virtual('bookings', {

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -49,7 +49,6 @@ const userSchema = new mongoose.Schema({
 });
 
 // 인덱스
-userSchema.index({ email: 1 });
 userSchema.index({ role: 1 });
 
 // 가상 필드

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
+const path = require('path');
 const connectDB = require('./config/database');
 const logger = require('./utils/logger');
 const { errorHandler } = require('./utils/errorHandler');
@@ -39,16 +40,23 @@ app.use('/api/', limiter);
 
 // 정적 파일 제공
 app.use('/uploads', express.static('uploads'));
+app.use(express.static(path.join(__dirname, '../frontend/public')));
 
 // API 라우트
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/users', require('./routes/users'));
 app.use('/api/taxis', require('./routes/taxis'));
+// Alias route to handle requests to /api/taxi
+app.use('/api/taxi', require('./routes/taxis'));
 app.use('/api/bookings', require('./routes/bookings'));
 app.use('/api/routes', require('./routes/routes'));
 
 // 헬스 체크 엔드포인트
 app.get('/health', (req, res) => {
+  res.json({ status: 'OK', message: 'Server is running' });
+});
+// health check endpoint under /api for backward compatibility
+app.get('/api/health', (req, res) => {
   res.json({ status: 'OK', message: 'Server is running' });
 });
 

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "YelloRide",
+  "name": "YelloRide Taxi Booking",
+  "icons": [
+    {
+      "src": "icon-192x192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- alias `/api/taxi` to existing taxis routes
- add `/api/health` endpoint and serve static files
- remove duplicate index definitions in User and Taxi models
- add `manifest.json` to public assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683ac18da564832bb963f95d90d701a3