### PR TITLE
Remove missing icon reference

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,13 +1,6 @@
 {
   "short_name": "YelloRide",
   "name": "YelloRide Taxi Booking",
-  "icons": [
-    {
-      "src": "icon-192x192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    }
-  ],
   "start_url": "/",
   "display": "standalone",
   "theme_color": "#ffffff",


### PR DESCRIPTION
## Summary
- remove `icons` entry from `frontend/public/manifest.json` to stop 404 requests for `icon-192x192.png`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ac50d94b4832bb4011631063ffd51