### PR TITLE
Fix search API error handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,8 @@ const { errorHandler } = require('./utils/errorHandler');
 
 // Express 앱 초기화
 const app = express();
+// Disable etag headers on responses to prevent 304 status issues
+app.disable('etag');
 
 // 데이터베이스 연결
 connectDB();
@@ -26,6 +28,11 @@ app.use(cors({
 // Body parser
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+// Prevent caching for API responses
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
 
 // HTTP 로깅
 app.use(logger.httpLogger());

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1621,8 +1621,10 @@ const HomePage = () => {
         sort: 'priority'
       });
       
-      if (response.success) {
+      if (response.success && Array.isArray(response.data)) {
         setPopularRoutes(response.data);
+      } else {
+        setPopularRoutes([]);
       }
     } catch (error) {
       console.error('인기 노선 로드 오류:', error);
@@ -1660,7 +1662,7 @@ const HomePage = () => {
         'kor'
       );
       
-      if (response.success && response.data.length > 0) {
+      if (response.success && Array.isArray(response.data) && response.data.length > 0) {
         setSearchResults(response.data);
         showToast(`${response.data.length}개의 경로를 찾았습니다.`, 'success');
       } else {


### PR DESCRIPTION
## Summary
- handle missing or cached taxi route data on the frontend
- disable Express etag and caching headers to prevent 304 responses

## Testing
- `npm test --workspaces --if-present` *(fails: No workspaces found)*
- `cd frontend && npm test --if-present` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ac7a081b4832bb8e88f5ce1a7778c