### PR TITLE
Fix taxi route endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -53,8 +53,8 @@ app.use(express.static(path.join(__dirname, '../frontend/public')));
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/users', require('./routes/users'));
 app.use('/api/taxis', require('./routes/taxis'));
-// Alias route to handle requests to /api/taxi
-app.use('/api/taxi', require('./routes/taxis'));
+// 택시 노선 조회를 위한 엔드포인트
+app.use('/api/taxi', require('./routes/taxiRoutes'));
 app.use('/api/bookings', require('./routes/bookings'));
 app.use('/api/routes', require('./routes/routes'));
 


### PR DESCRIPTION
## Summary
- adjust server routing so `/api/taxi` resolves to `taxiRoutes`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683ace0f7620832b8b989becedf95847