### PR TITLE
Add product model and import script

### DIFF
--- a/backend/data/taxiitems.json
+++ b/backend/data/taxiitems.json
@@ -1,0 +1,5 @@
+[
+  {"region":"NY","departure_kor":"NY 자메이카","departure_eng":"NY Jamaica","departure_is_airport":"N","arrival_kor":"NY 존에프케네디 공항 - JFK airport","arrival_eng":"JFK airport NY","reservation_fee":20,"local_payment_fee":35,"arrival_is_airport":"Y","priority":1},
+  {"region":"NY","departure_kor":"NY 존에프케네디 공항 - JFK airport","departure_eng":"JFK airport NY","departure_is_airport":"Y","arrival_kor":"NY 맨하탄 미드타운 - Manhattan Midtown","arrival_eng":"Manhattan Midtown NY","reservation_fee":20,"local_payment_fee":75,"arrival_is_airport":"N","priority":1},
+  {"region":"NY","departure_kor":"NY 존에프케네디 공항 - JFK airport","departure_eng":"JFK airport NY","departure_is_airport":"Y","arrival_kor":"NY 브루클린 - Brooklyn","arrival_eng":"Brooklyn NY","reservation_fee":20,"local_payment_fee":55,"arrival_is_airport":"N","priority":3}
+]

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const productSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  taxiItem: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'TaxiItem',
+    required: true,
+  },
+  price: {
+    type: Number,
+    required: true,
+    min: 0,
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  is_active: {
+    type: Boolean,
+    default: true,
+  },
+}, {
+  timestamps: true,
+  collection: 'products',
+});
+
+module.exports = mongoose.model('Product', productSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon server.js",
     "seed": "node scripts/seedData.js",
     "seed:taxi": "node scripts/seedTaxiData.js",
-    "import:taxi": "node scripts/importTaxiData.js"
+    "import:taxi": "node scripts/importTaxiData.js",
+    "import:json": "node scripts/importTaxiJson.js"
   },
   "keywords": [
     "taxi",

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const Product = require('../models/Product');
+const TaxiItem = require('../models/TaxiItem');
+
+// 전체 상품 조회
+router.get('/', async (req, res) => {
+  try {
+    const products = await Product.find({ is_active: true }).populate('taxiItem');
+    res.json({ success: true, data: products });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, message: '상품 조회 오류' });
+  }
+});
+
+// 상품 생성
+router.post('/', async (req, res) => {
+  try {
+    const { name, taxiItemId, price, description } = req.body;
+    const taxiItem = await TaxiItem.findById(taxiItemId);
+    if (!taxiItem) {
+      return res.status(404).json({ success: false, message: '노선을 찾을 수 없습니다.' });
+    }
+    const product = await Product.create({ name, taxiItem: taxiItemId, price, description });
+    res.status(201).json({ success: true, data: product });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, message: '상품 생성 오류' });
+  }
+});
+
+module.exports = router;

--- a/backend/scripts/importTaxiJson.js
+++ b/backend/scripts/importTaxiJson.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const TaxiItem = require('../models/TaxiItem');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+async function importFromJson(filePath) {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/yelloride', {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (!Array.isArray(data)) {
+      throw new Error('JSON 파일 형식이 올바르지 않습니다.');
+    }
+
+    const result = await TaxiItem.insertMany(data);
+    console.log(`${result.length}개의 택시 노선이 추가되었습니다.`);
+  } catch (err) {
+    console.error('데이터 임포트 오류:', err);
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+const jsonPath = process.argv[2] || path.resolve(__dirname, '../data/taxiitems.json');
+importFromJson(jsonPath);

--- a/backend/server.js
+++ b/backend/server.js
@@ -57,6 +57,7 @@ app.use('/api/taxis', require('./routes/taxis'));
 app.use('/api/taxi', require('./routes/taxiRoutes'));
 app.use('/api/bookings', require('./routes/bookings'));
 app.use('/api/routes', require('./routes/routes'));
+app.use('/api/products', require('./routes/products'));
 
 // 헬스 체크 엔드포인트
 app.get('/health', (req, res) => {


### PR DESCRIPTION
## Summary
- add Product model referencing TaxiItem
- expose `/api/products` endpoints
- provide JSON dataset with a script to import TaxiItem data

## Testing
- `npm test --silent`
- `node scripts/importTaxiJson.js data/taxiitems.json` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_b_683ad234df20832b9d09156f19ce67cb