### PR TITLE
Update MongoDB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm run seed:taxi   # 택시 데이터만 생성
 npm run import:json -- --clear   # JSON 파일로 모든 택시 노선 갱신
 ```
 
-백엔드 서버를 처음 실행하면 데이터베이스에 노선이 없는 경우 `backend/data/taxiitems_full.json` 파일을 읽어 자동으로 채워 넣습니다.
+백엔드 서버를 처음 실행하면 데이터베이스에 노선이 없는 경우 `backend/data/taxiitems_full.json` 파일을 읽어 `taxi_item` 컬렉션에 자동으로 데이터를 채워 넣습니다.
 
 ### 프로덕션 빌드
 ```bash
@@ -200,6 +200,8 @@ yelloride/
 |--------|------|------|
 | PORT | 서버 포트 | 5001 |
 | MONGODB_URI | MongoDB 연결 URI | mongodb://localhost:27017/yelloride |
+| DB_NAME | 데이터베이스 이름 | yelloride |
+| TAXI_COLLECTION | 택시 노선 컬렉션 | taxi_item |
 | JWT_SECRET | JWT 비밀 키 | your-secret-key |
 | JWT_EXPIRE | JWT 만료 시간 | 30d |
 | NODE_ENV | 실행 환경 | development/production |

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -2,7 +2,9 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/yelloride', {
+    const dbName = process.env.DB_NAME || 'yelloride';
+    const uri = process.env.MONGODB_URI || `mongodb://localhost:27017/${dbName}`;
+    const conn = await mongoose.connect(uri, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
       serverSelectionTimeoutMS: 5000,

--- a/backend/models/TaxiItem.js
+++ b/backend/models/TaxiItem.js
@@ -58,7 +58,7 @@ const taxiItemSchema = new mongoose.Schema({
   }
 }, {
   timestamps: true,
-  collection: 'taxiitems'
+  collection: process.env.TAXI_COLLECTION || 'taxi_item'
 });
 
 // 인덱스 설정


### PR DESCRIPTION
## Summary
- allow configuring DB name and taxi collection
- clarify seeding into `taxi_item` collection in README

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683af06c2a44832bab99374fcb80396a