### PR TITLE
Fix missing Users and Luggage icons import

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
-import { ArrowLeft, Plus, Minus, X, ChevronRight, MapPin, Clock, Calendar, Search, Info, Plane, Building2, Car, CheckCircle, Phone, HeadphonesIcon, User, Menu, Globe, FileText } from 'lucide-react';
+import { ArrowLeft, Plus, Minus, X, ChevronRight, MapPin, Clock, Calendar, Search, Info, Plane, Building2, Car, CheckCircle, Phone, HeadphonesIcon, User, Users, Luggage, Menu, Globe, FileText } from 'lucide-react';
 
 // 전역 상태 관리
 const AppContext = createContext();


### PR DESCRIPTION
## Summary
- import `Users` and `Luggage` icons from lucide-react

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683afbafd204832b9440a01fc5210f03