### PR TITLE
Stop using local taxi seed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm run seed:taxi   # 택시 데이터만 생성
 npm run import:json -- --clear   # JSON 파일로 모든 택시 노선 갱신
 ```
 
-백엔드 서버를 처음 실행하면 데이터베이스에 노선이 없는 경우 `backend/data/taxiitems_full.json` 파일을 읽어 `taxi_item` 컬렉션에 자동으로 데이터를 채워 넣습니다.
+초기 택시 노선 데이터는 MongoDB에 직접 임포트해야 합니다. 필요 시 `npm run import:json -- --clear` 명령을 사용해 `backend/data/taxiitems_full.json` 파일의 내용을 컬렉션에 삽입할 수 있습니다.
 
 ### 프로덕션 빌드
 ```bash

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,6 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
-const fs = require('fs');
 const connectDB = require('./config/database');
 const logger = require('./utils/logger');
 const { errorHandler } = require('./utils/errorHandler');
@@ -15,27 +14,9 @@ const app = express();
 // Disable etag headers on responses to prevent 304 status issues
 app.disable('etag');
 
-async function seedTaxiDataIfEmpty() {
-  try {
-    const count = await TaxiItem.countDocuments();
-    if (count === 0) {
-      const dataPath = path.join(__dirname, 'data', 'taxiitems_full.json');
-      if (fs.existsSync(dataPath)) {
-        const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-        await TaxiItem.insertMany(data);
-        console.log(`Seeded ${data.length} taxi routes`);
-      } else {
-        console.log('Taxi seed file not found:', dataPath);
-      }
-    }
-  } catch (err) {
-    console.error('Taxi seed error:', err);
-  }
-}
 
 async function startServer() {
   await connectDB();
-  await seedTaxiDataIfEmpty();
 
 
 // 보안 미들웨어


### PR DESCRIPTION
## Summary
- remove automatic taxi seed from `backend/server.js`
- update README to explain manual MongoDB import

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b0df4cd54832b90aecf04df583cf6