### PR TITLE
Fix region data error, remove auth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ YelloRide는 사용자가 편리하게 택시를 예약하고, 운전자가 효�
 ## 🚀 주요 기능
 
 ### 사용자 기능
-- 회원가입 및 로그인
 - 택시 예약 생성/조회/취소
 - 실시간 택시 위치 확인
 - 예약 이력 관리
-- 프로필 관리
 
 ### 운전자 기능
 - 예약 요청 확인 및 수락/거절
@@ -146,12 +144,6 @@ npm start
 ```
 
 ## 📡 API 엔드포인트
-
-### 인증 관련
-- `POST /api/auth/register` - 회원가입
-- `POST /api/auth/login` - 로그인
-- `GET /api/auth/profile` - 프로필 조회
-- `PUT /api/auth/profile` - 프로필 수정
 
 ### 택시 관련
 - `GET /api/taxis` - 택시 목록 조회

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -423,7 +423,7 @@ const ConnectionStatus = () => {
 
 // 관리자 페이지
 const AdminPage = () => {
-  const { setCurrentPage, api, showToast } = useContext(AppContext);
+  const { setCurrentPage, api, showToast, regionData } = useContext(AppContext);
   const [activeTab, setActiveTab] = useState('data');
   const [taxiData, setTaxiData] = useState([]);
   const [stats, setStats] = useState([]);


### PR DESCRIPTION
## Summary
- load `regionData` via context in AdminPage
- remove authentication details from docs

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_683ba3411aac832bbb8b02d1541dda57