### PR TITLE
Support lang filter in route search

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -78,10 +78,18 @@ app.get('/api/taxi/all', async (req, res) => {
 // 경로 검색
 app.get('/api/taxi/route', async (req, res) => {
   try {
-    const { departure, arrival } = req.query;
+    const { departure, arrival, lang = 'kor' } = req.query;
     const filter = {};
-    if (departure) filter.departure_kor = departure;
-    if (arrival) filter.arrival_kor = arrival;
+
+    if (departure) {
+      const depKey = lang === 'eng' ? 'departure_eng' : 'departure_kor';
+      filter[depKey] = departure;
+    }
+    if (arrival) {
+      const arrKey = lang === 'eng' ? 'arrival_eng' : 'arrival_kor';
+      filter[arrKey] = arrival;
+    }
+
     const item = await TaxiItem.findOne(filter);
     if (!item) {
       return res.status(404).json({ success: false, message: 'Route not found' });


### PR DESCRIPTION
## Summary
- enhance `/api/taxi/route` endpoint
  - add `lang` query parameter to search by Korean or English fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683bacac40ac832b8afa9e07d0797d73