### PR TITLE
Add backend .env and env logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules/
 # Misc
 .DS_Store
 .env
+!backend/.env
 .env.local
 .env.development.local
 .env.test.local

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb://localhost:27017/yelloride

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const crypto = require('crypto');
 require('dotenv').config();
 
+console.log('Loaded MONGODB_URI:', process.env.MONGODB_URI);
 const app = express();
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add example MongoDB config to backend/.env
- log loaded MONGODB_URI when starting backend server
- update .gitignore to include backend/.env

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_683bb3381b50832b8e1f5d3eb28595cb