### PR TITLE
Add detailed booking logging

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -248,11 +248,20 @@ app.get('/api/taxi/stats', async (req, res) => {
 
 // 예약 생성
 app.post('/api/bookings', async (req, res) => {
-  console.log('POST /api/bookings 요청됨');
-  console.log('요청 바디:', req.body);
+  console.log('=== 예약 요청 시작 ===');
+  console.log('요청 시간:', new Date().toISOString());
+  console.log('요청 헤더:', req.headers);
+  console.log('요청 바디:', JSON.stringify(req.body, null, 2));
 
   try {
     const data = req.body;
+
+    // 각 단계별 로깅 추가
+    console.log('1. 데이터 검증 시작');
+
+    // vehicles 검증
+    console.log('2. vehicles 타입:', typeof data.vehicles);
+    console.log('   vehicles 내용:', data.vehicles);
 
     // vehicles 타입 검증
     if (typeof data.vehicles === 'string') {
@@ -296,7 +305,11 @@ app.post('/api/bookings', async (req, res) => {
     res.json({ success: true, data: booking });
 
   } catch (err) {
-    console.error('Booking creation error:', err);
+    console.error('❌ 예약 생성 실패');
+    console.error('에러 타입:', err.name);
+    console.error('에러 메시지:', err.message);
+    console.error('스택 트레이스:', err.stack);
+
     console.error('[BOOKING_ERROR]', {
       timestamp: new Date().toISOString(),
       error: err.message,
@@ -307,6 +320,11 @@ app.post('/api/bookings', async (req, res) => {
 
     // Mongoose validation error 처리
     if (err.name === 'ValidationError') {
+      console.error('검증 에러 상세:');
+      Object.keys(err.errors).forEach(field => {
+        console.error(`  - ${field}: ${err.errors[field].message}`);
+      });
+
       const errors = Object.values(err.errors).map(e => e.message);
       return res.status(400).json({
         success: false,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1984,6 +1984,9 @@ const BookingPage = () => {
   };
 
   const completeBooking = async () => {
+    console.log('=== 예약 요청 데이터 ===');
+    console.log('bookingData:', bookingData);
+    console.log('priceData:', priceData);
     if (!validateStep(currentStep)) {
       showToast('예약 정보를 다시 확인해주세요.', 'error');
       return;
@@ -2027,11 +2030,21 @@ const BookingPage = () => {
         pricing: {
           reservation_fee: priceData.reservation_fee,
           service_fee: priceData.local_payment_fee,
-          vehicle_upgrade_fee: bookingData.vehicle === 'xl' ? priceData.vehicle_upgrades.xl_fee : 
+          vehicle_upgrade_fee: bookingData.vehicle === 'xl' ? priceData.vehicle_upgrades.xl_fee :
                               bookingData.vehicle === 'premium' ? priceData.vehicle_upgrades.premium_fee : 0,
           total_amount: calculateTotalPrice()
         }
       };
+
+      // 요청 전 데이터 검증
+      console.log('전송할 예약 데이터:', JSON.stringify(bookingRequest, null, 2));
+
+      // vehicles 배열 확인
+      if (typeof bookingRequest.vehicles === 'string') {
+        console.error('❌ vehicles가 문자열입니다!');
+        showToast('데이터 형식 오류가 발생했습니다', 'error');
+        return;
+      }
 
       const response = await api.createBooking(bookingRequest);
       
@@ -2049,7 +2062,7 @@ const BookingPage = () => {
         throw new Error(response.message || '예약 생성에 실패했습니다.');
       }
     } catch (error) {
-      console.error('예약 오류:', error);
+      console.error('예약 실패 상세:', error);
       showToast(error.message || '예약 중 오류가 발생했습니다. 다시 시도해주세요.', 'error');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- improve booking API logging with detailed request/response data
- add client-side logging and validations before sending booking request

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bbba92274832b997c6eaeb7b1c0ce