### PR TITLE
Fix booking schema service_info object

### DIFF
--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -1,46 +1,72 @@
 const mongoose = require('mongoose');
 
 const bookingSchema = new mongoose.Schema({
-  booking_number: { type: String, required: true, unique: true },
+  booking_number: { 
+    type: String, 
+    required: true, 
+    unique: true 
+  },
+  
   customer_info: {
-    name: String,
-    phone: String,
-    kakao_id: String
+    name: { type: String, required: true },
+    phone: { type: String, required: true },
+    kakao_id: { type: String }
   },
+  
+  // service_info as object
   service_info: {
-    type: String,
-    region: String
+    type: { type: String, required: true },
+    region: { type: String, required: true }
   },
+  
   trip_details: {
     departure: {
-      location: String,
-      datetime: Date
+      location: { type: String, required: true },
+      datetime: { type: Date, required: true }
     },
     arrival: {
-      location: String,
-      datetime: Date
+      location: { type: String, required: true },
+      datetime: { type: Date }  // optional arrival time
     }
   },
+  
+  // vehicles is array
   vehicles: [{
     type: { type: String, required: true },
-    passengers: Number,
-    luggage: Number
+    passengers: { type: Number, default: 0 },
+    luggage: { type: Number, default: 0 }
   }],
+  
   passenger_info: {
-    total_passengers: Number,
-    total_luggage: Number
+    total_passengers: { type: Number },
+    total_luggage: { type: Number }
   },
+  
   flight_info: {
-    flight_number: String,
-    terminal: String
+    flight_number: { type: String },
+    terminal: { type: String }
   },
+  
   pricing: {
-    reservation_fee: Number,
-    service_fee: Number,
-    vehicle_upgrade_fee: Number,
-    total_amount: Number
+    reservation_fee: { type: Number, default: 0 },
+    service_fee: { type: Number, default: 0 },
+    vehicle_upgrade_fee: { type: Number, default: 0 },
+    total_amount: { type: Number, required: true }
   },
-  status: { type: String, default: 'pending' }
-}, { timestamps: true, collection: 'bookings' });
+  
+  status: { 
+    type: String, 
+    enum: ['pending', 'confirmed', 'completed', 'cancelled'],
+    default: 'pending' 
+  }
+  
+}, { 
+  timestamps: true  // createdAt, updatedAt automatically added
+});
+
+bookingSchema.index({ booking_number: 1 });
+bookingSchema.index({ 'customer_info.phone': 1 });
+bookingSchema.index({ status: 1 });
+bookingSchema.index({ createdAt: -1 });
 
 module.exports = mongoose.model('Booking', bookingSchema);

--- a/backend/tests/booking.test.js
+++ b/backend/tests/booking.test.js
@@ -5,7 +5,12 @@ describe('Booking API Tests', () => {
   test('should create booking', async () => {
     const validBooking = {
       customer_info: { name: 'Test', phone: '010-1234-5678' },
-      vehicles: [{ type: 'standard', passengers: 1, luggage: 0 }]
+      service_info: { type: 'airport', region: 'NY' },
+      trip_details: {
+        departure: { location: 'Test Departure', datetime: new Date().toISOString() }
+      },
+      vehicles: [{ type: 'standard', passengers: 1, luggage: 0 }],
+      pricing: { total_amount: 100 }
     };
 
     const response = await request(app)


### PR DESCRIPTION
## Summary
- define `service_info` as an object with `type` and `region`
- add indexes and detailed schema fields
- update booking API test to send service_info object

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bea3bb6f4832bb366894262ba0b23