### PR TITLE
Fix booking search route order

### DIFF
--- a/backend/tests/booking.test.js
+++ b/backend/tests/booking.test.js
@@ -20,4 +20,27 @@ describe('Booking API Tests', () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
   });
+
+  test('should search booking by number', async () => {
+    const booking = {
+      customer_info: { name: 'Search', phone: '010-0000-0000' },
+      service_info: { type: 'airport', region: 'NY' },
+      trip_details: {
+        departure: { location: 'Test', datetime: new Date().toISOString() }
+      },
+      vehicles: [{ type: 'standard', passengers: 1, luggage: 0 }],
+      pricing: { total_amount: 100 }
+    };
+
+    const createRes = await request(app).post('/api/bookings').send(booking);
+    const bookingNumber = createRes.body.data.booking_number;
+
+    const searchRes = await request(app)
+      .get('/api/bookings/search')
+      .query({ booking_number: bookingNumber });
+
+    expect(searchRes.status).toBe(200);
+    expect(searchRes.body.success).toBe(true);
+    expect(searchRes.body.data.booking_number).toBe(bookingNumber);
+  });
 });


### PR DESCRIPTION
## Summary
- log booking request details
- implement `/api/bookings/search` fully and reorder booking routes
- add listing endpoint and adjust tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bf3210d10832b838387c921ef1f5f