### PR TITLE
Add Excel upload feature

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "mongoose": "^7.6.1"
+    "mongoose": "^7.6.1",
+    "multer": "^1.4.5-lts.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",


### PR DESCRIPTION
## Summary
- allow uploading Excel files to populate `taxi_item`
- parse the file server-side and insert into MongoDB
- expose API `/api/taxi/upload`
- support Excel upload from admin page
- tweak API client to allow FormData uploads

## Testing
- `npm install` *(fails: network unavailable)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cdf9af53c832bb0afe33683eab880