### PR TITLE
Support JSON route data upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npm start
 - `POST /api/taxis` - 택시 등록 (관리자)
 - `PUT /api/taxis/:id` - 택시 정보 수정
 - `DELETE /api/taxis/:id` - 택시 삭제
+- `POST /api/taxi/upload` - 엑셀 또는 JSON 파일로 노선 데이터 업로드
 
 ### 예약 관련
 - `GET /api/bookings` - 예약 목록 조회

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -147,6 +147,14 @@ class YellorideAPI {
     });
   }
 
+  async uploadTaxiJson(data) {
+    return this.requestWithRetry('/taxi/upload', {
+      method: 'POST',
+      body: JSON.stringify({ data }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
   // 입력 데이터 검증
   validateBookingData(bookingData) {
     const errors = [];
@@ -778,12 +786,18 @@ const AdminPage = () => {
       return;
     }
 
-    const formData = new FormData();
-    formData.append('file', selectedFile);
-
     setUploading(true);
     try {
-      const response = await api.uploadTaxiExcel(formData);
+      let response;
+      if (selectedFile.name.endsWith('.json')) {
+        const text = await selectedFile.text();
+        const data = JSON.parse(text);
+        response = await api.uploadTaxiJson(data);
+      } else {
+        const formData = new FormData();
+        formData.append('file', selectedFile);
+        response = await api.uploadTaxiExcel(formData);
+      }
       if (response.success) {
         showToast('업로드가 완료되었습니다.', 'success');
         loadTaxiData();


### PR DESCRIPTION
## Summary
- allow JSON format for `/api/taxi/upload`
- detect `.json` files in the frontend and send JSON data
- document the new endpoint in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ce32c4334832bb8fb25e449f86789